### PR TITLE
Use cloud tools for RHOAM installation

### DIFF
--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -275,10 +275,10 @@ class ClusterAddOn(Cluster):
             if param not in user_addon_parameters:
                 missing_parameter.append(param)
 
-        # if missing_parameter:
-        #     raise ValueError(
-        #         f"{self.addon_name} missing some required parameters {missing_parameter}"
-        #     )
+        if missing_parameter:
+            raise ValueError(
+                f"{self.addon_name} missing some required parameters {missing_parameter}"
+            )
 
     def install_addon(
         self,

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -3,7 +3,7 @@ from importlib.util import find_spec
 
 import rosa.cli as rosa_cli
 import yaml
-from clouds.aws.aws_roles.aws_roles import create_or_update_role_policy
+from clouds.aws.roles.roles import create_or_update_role_policy
 from ocm_python_client import ApiException
 from ocm_python_client.exceptions import NotFoundException
 from ocm_python_client.model.add_on import AddOn

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -1,3 +1,4 @@
+import os
 from importlib.util import find_spec
 
 import rosa.cli as rosa_cli
@@ -345,8 +346,13 @@ class ClusterAddOn(Cluster):
         ):
             # Create role-policy for RHOAM installation:
             # https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management/1/guide/53dfb804-2038-4545-b917-2cb01a09ef98#_b5f80fce-73cb-4869-aa16-763bbe09896a:~:text=In%20the%20AWS%20CLI%2C%20create%20a%20policy%20for%20SRE%20Support.%20Enter%20the%20following%3A
-            path = find_spec("ocm_python_wrapper").submodule_search_locations[0]
-            with open(path + "/manifests/managed-api-service-policy.json", "r") as fd:
+            with open(
+                os.path.join(
+                    find_spec("ocm_python_wrapper").submodule_search_locations[0],
+                    "manifests/managed-api-service-policy.json",
+                ),
+                "r",
+            ) as fd:
                 policy_document = fd.read()
             create_or_update_role_policy(
                 role_name="ManagedOpenShift-Support-Role",

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -1,5 +1,6 @@
 import rosa.cli as rosa_cli
 import yaml
+from clouds.aws.aws_roles.aws_roles import create_or_update_role_policy
 from ocm_python_client import ApiException
 from ocm_python_client.exceptions import NotFoundException
 from ocm_python_client.model.add_on import AddOn
@@ -274,10 +275,10 @@ class ClusterAddOn(Cluster):
             if param not in user_addon_parameters:
                 missing_parameter.append(param)
 
-        if missing_parameter:
-            raise ValueError(
-                f"{self.addon_name} missing some required parameters {missing_parameter}"
-            )
+        # if missing_parameter:
+        #     raise ValueError(
+        #         f"{self.addon_name} missing some required parameters {missing_parameter}"
+        #     )
 
     def install_addon(
         self,
@@ -340,6 +341,13 @@ class ClusterAddOn(Cluster):
             self.addon_name == "managed-api-service"
             and "stage" in self.client.api_client.configuration.host
         ):
+            # Create role-policy for RHOAM installation:
+            # https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management/1/guide/53dfb804-2038-4545-b917-2cb01a09ef98#_b5f80fce-73cb-4869-aa16-763bbe09896a:~:text=In%20the%20AWS%20CLI%2C%20create%20a%20policy%20for%20SRE%20Support.%20Enter%20the%20following%3A
+            create_or_update_role_policy(
+                role_name="ManagedOpenShift-Support-Role",
+                policy_name="rhoam-sre-support-policy",
+                policy_document_path="manifests/managed-api-service-policy.json",
+            )
             self.update_rhoam_cluster_storage_config()
 
         if wait:

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -1,4 +1,3 @@
-import json
 from importlib.util import find_spec
 
 import rosa.cli as rosa_cli
@@ -348,7 +347,7 @@ class ClusterAddOn(Cluster):
             # https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management/1/guide/53dfb804-2038-4545-b917-2cb01a09ef98#_b5f80fce-73cb-4869-aa16-763bbe09896a:~:text=In%20the%20AWS%20CLI%2C%20create%20a%20policy%20for%20SRE%20Support.%20Enter%20the%20following%3A
             path = find_spec("ocm_python_wrapper").submodule_search_locations[0]
             with open(path + "/manifests/managed-api-service-policy.json", "r") as fd:
-                policy_document = json.dumps(json.loads(fd.read()))
+                policy_document = fd.read()
             create_or_update_role_policy(
                 role_name="ManagedOpenShift-Support-Role",
                 policy_name="rhoam-sre-support-policy",

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -1,3 +1,4 @@
+import json
 from importlib.util import find_spec
 
 import rosa.cli as rosa_cli
@@ -347,7 +348,7 @@ class ClusterAddOn(Cluster):
             # https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management/1/guide/53dfb804-2038-4545-b917-2cb01a09ef98#_b5f80fce-73cb-4869-aa16-763bbe09896a:~:text=In%20the%20AWS%20CLI%2C%20create%20a%20policy%20for%20SRE%20Support.%20Enter%20the%20following%3A
             path = find_spec("ocm_python_wrapper").submodule_search_locations[0]
             with open(path + "/manifests/managed-api-service-policy.json", "r") as fd:
-                policy_document = fd.read()
+                policy_document = json.dumps(json.loads(fd.read()))
             create_or_update_role_policy(
                 role_name="ManagedOpenShift-Support-Role",
                 policy_name="rhoam-sre-support-policy",

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import rosa.cli as rosa_cli
 import yaml
 from clouds.aws.aws_roles.aws_roles import create_or_update_role_policy
@@ -343,10 +345,13 @@ class ClusterAddOn(Cluster):
         ):
             # Create role-policy for RHOAM installation:
             # https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management/1/guide/53dfb804-2038-4545-b917-2cb01a09ef98#_b5f80fce-73cb-4869-aa16-763bbe09896a:~:text=In%20the%20AWS%20CLI%2C%20create%20a%20policy%20for%20SRE%20Support.%20Enter%20the%20following%3A
+            path = find_spec("ocm_python_wrapper").submodule_search_locations[0]
+            with open(path + "/manifests/managed-api-service-policy.json", "r") as fd:
+                policy_document = fd.read()
             create_or_update_role_policy(
                 role_name="ManagedOpenShift-Support-Role",
                 policy_name="rhoam-sre-support-policy",
-                policy_document_path="manifests/managed-api-service-policy.json",
+                policy_document=policy_document,
             )
             self.update_rhoam_cluster_storage_config()
 

--- a/ocm_python_wrapper/manifests/managed-api-service-policy.json
+++ b/ocm_python_wrapper/manifests/managed-api-service-policy.json
@@ -1,0 +1,26 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "rds:DescribeGlobalClusters",
+                "rds:ModifyDBInstance",
+                "rds:DeleteDBInstance",
+                "rds:DescribeDBSnapshots",
+                "rds:RestoreDBInstanceFromDBSnapshot",
+                "elasticache:DescribeReplicationGroups",
+                "elasticache:ModifyReplicationGroup",
+                "elasticache:DescribeSnapshots",
+                "elasticache:CreateReplicationGroup",
+                "elasticache:DescribeCacheClusters",
+                "elasticache:DeleteReplicationGroup",
+                "sts:GetCallerIdentity",
+                "tag:TagResources"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,9 @@ dependencies = [
     "pyyaml",
     "openshift-python-utilities",
     "rosa-python-client",
-    "python-simple-logger"
+    "python-simple-logger",
+    "redhat-qe-cloud-tools",
+    "importlib",
 ]
 dynamic = ["version"]
 # ...
@@ -64,3 +66,6 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 include = ["ocm_python_wrapper"]
+
+[tool.setuptools.package-data]
+ocm_python_wrapper = ["manifests/*.json"]


### PR DESCRIPTION
Update/create a specific AWS IAM role-policy required by [docs](https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management/1/guide/53dfb804-2038-4545-b917-2cb01a09ef98#_b5f80fce-73cb-4869-aa16-763bbe09896a:~:text=In%20the%20AWS%20CLI%2C%20create%20a%20policy%20for%20SRE%20Support.%20Enter%20the%20following%3A) for RHOAM installation.