### PR TITLE
Update _wait_for_rhoam

### DIFF
--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -24,7 +24,7 @@ from simple_logger.logger import get_logger
 from ocm_python_wrapper.exceptions import MissingResourceError
 
 LOGGER = get_logger(__name__)
-TIMEOUT_5MIN = 5 * 60
+TIMEOUT_15MIN = 15 * 60
 TIMEOUT_10MIN = 10 * 60
 TIMEOUT_30MIN = 30 * 60
 SLEEP_1SEC = 1
@@ -396,7 +396,7 @@ class ClusterAddOn(Cluster):
 
         def _wait_for_rhoam_installation(_command):
             for rosa_sampler in self.addon_installation_instance_sampler(
-                func=rosa_cli.execute, wait_timeout=TIMEOUT_5MIN, command=_command
+                func=rosa_cli.execute, wait_timeout=TIMEOUT_15MIN, command=_command
             ):
                 return rosa_sampler
 

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -398,9 +398,7 @@ class ClusterAddOn(Cluster):
             for rosa_sampler in self.addon_installation_instance_sampler(
                 func=rosa_cli.execute, wait_timeout=TIMEOUT_15MIN, command=_command
             ):
-                LOGGER.info(
-                    f"{rosa_sampler['out'].split_lines()}\n{rosa_sampler['err'].split_lines()}"
-                )
+                LOGGER.info(f"{rosa_sampler['out']}{rosa_sampler['err']}")
                 return rosa_sampler
 
         addon = AddOn(id=self.addon_name)

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -398,7 +398,7 @@ class ClusterAddOn(Cluster):
             for rosa_sampler in self.addon_installation_instance_sampler(
                 func=rosa_cli.execute, wait_timeout=TIMEOUT_15MIN, command=_command
             ):
-                LOGGER.info(f"{rosa_sampler['out']}{rosa_sampler['err']}")
+                LOGGER.info(f"{rosa_sampler['out'] or ''}{rosa_sampler['err'] or ''}")
                 return rosa_sampler
 
         addon = AddOn(id=self.addon_name)

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -398,6 +398,9 @@ class ClusterAddOn(Cluster):
             for rosa_sampler in self.addon_installation_instance_sampler(
                 func=rosa_cli.execute, wait_timeout=TIMEOUT_15MIN, command=_command
             ):
+                LOGGER.info(
+                    f"{rosa_sampler['out'].split_lines()}\n{rosa_sampler['err'].split_lines()}"
+                )
                 return rosa_sampler
 
         addon = AddOn(id=self.addon_name)

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -398,7 +398,6 @@ class ClusterAddOn(Cluster):
             for rosa_sampler in self.addon_installation_instance_sampler(
                 func=rosa_cli.execute, wait_timeout=TIMEOUT_15MIN, command=_command
             ):
-                LOGGER.info(f"{rosa_sampler['out'] or ''}{rosa_sampler['err'] or ''}")
                 return rosa_sampler
 
         addon = AddOn(id=self.addon_name)


### PR DESCRIPTION
Recent openshift-ci [rehearses](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/40151/rehearse-40151-periodic-ci-CSPI-QE-MSI-rhods-rhoam-addons-v4.13-rhods-rhoam-tests/1668156753423896576) failed twice with 
`ocp_resources.utils.TimeoutExpiredError: Timed Out: 300` while installing RHOAM addon with our sampler.

Changes:
1. Update logging to catch unexpected errors (in addition to the one that's covered by the sampler)
2. Update timeout to be 15 minutes