### PR TITLE
Brew auth is default to not be set

### DIFF
--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -580,7 +580,7 @@ class ClusterAddOn(Cluster):
         ).update()
 
     @staticmethod
-    def create_rhods_brew_config(brew_token):
+    def create_rhods_brew_config(brew_token=None):
         icsp_name = "ocp-mgmt-wrapper-brew-registry"
         icsp = ImageContentSourcePolicy(name=icsp_name)
         if icsp.exists:
@@ -595,7 +595,10 @@ class ClusterAddOn(Cluster):
                 }
             ],
         )
-        secret_data_dict = {"auths": {"brew.registry.redhat.io": {"auth": brew_token}}}
+
+        secret_data_dict = {"auths": {"brew.registry.redhat.io": {}}}
+        if brew_token:
+            secret_data_dict["auths"]["brew.registry.redhat.io"]["auth"] = brew_token
         create_update_secret(
             secret_data_dict=secret_data_dict,
             name="pull-secret",  # pragma: allowlist secret


### PR DESCRIPTION
Brew token is not mandatory for rhods addon since we pick released version from the API.
For version 1.29.0 the fact we set it caused failures.