### PR TITLE
Cluster: Remove cluster_id call from __init__

### DIFF
--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -48,7 +48,10 @@ class Cluster:
     def __init__(self, client, name):
         self.client = client
         self.name = name
-        self.cluster_id = None
+        try:
+            self.cluster_id = self._cluster_id()
+        except MissingResourceError:
+            self.cluster_id = None
 
     def _cluster_id(self):
         cluster_list = self.client.api_clusters_mgmt_v1_clusters_get(

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -384,7 +384,6 @@ class Cluster:
             missing_attributes = [
                 attr_name
                 for attr_name in [
-                    "name",
                     "region",
                     "ocp_version",
                     "access_key_id",

--- a/ocm_python_wrapper/cluster.py
+++ b/ocm_python_wrapper/cluster.py
@@ -247,7 +247,7 @@ class Cluster:
         """
         try:
             return self.instance
-        except NotFoundException:
+        except (NotFoundException, MissingResourceError):
             return None
 
     @property


### PR DESCRIPTION
Cluster class should not force the cluster to be exists when initializing the class instance.